### PR TITLE
Bump rust version to 1.46

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.42.0
+          - 1.46.0
         profile:
           - name: debug
           - name: release


### PR DESCRIPTION
This allows for supporting newer versions of the bitfields crate