### PR TITLE
fix: rename kvmEncRegion to KvmEncRegion

### DIFF
--- a/src/kvm.rs
+++ b/src/kvm.rs
@@ -18,12 +18,12 @@ pub const ENC_OP: Ioctl<WriteRead, &c_ulong> = unsafe { KVM.write_read(0xBA) };
 // the write with a reference, too.
 
 /// Corresponds to the `KVM_MEMORY_ENCRYPT_REG_REGION` ioctl
-pub const ENC_REG_REGION: Ioctl<Write, &kvmEncRegion> =
-    unsafe { KVM.read::<kvmEncRegion>(0xBB).lie() };
+pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion> =
+    unsafe { KVM.read::<KvmEncRegion>(0xBB).lie() };
 
 /// Corresponds to the `KVM_MEMORY_ENCRYPT_UNREG_REGION` ioctl
-pub const ENC_UNREG_REGION: Ioctl<Write, &kvmEncRegion> =
-    unsafe { KVM.read::<kvmEncRegion>(0xBC).lie() };
+pub const ENC_UNREG_REGION: Ioctl<Write, &KvmEncRegion> =
+    unsafe { KVM.read::<KvmEncRegion>(0xBC).lie() };
 
 /// The Rust-flavored, FFI-friendly version of `struct sev_issue_cmd` which is
 /// used to pass arguments to the SEV ioctl implementation.
@@ -79,14 +79,14 @@ impl<'a, T: Id> Command<'a, T> {
 /// Corresponds to the kernel struct `kvm_enc_region`
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub struct kvmEncRegion<'a> {
+pub struct KvmEncRegion<'a> {
     addr: u64,
     size: u64,
     phantom: PhantomData<&'a [u8]>,
 }
 
-impl<'a> kvmEncRegion<'a> {
-    /// Create a new `kvmEncRegion` referencing some memory assigned to the virtual machine.
+impl<'a> KvmEncRegion<'a> {
+    /// Create a new `KvmEncRegion` referencing some memory assigned to the virtual machine.
     pub fn new(data: &'a [u8]) -> Self {
         Self {
             addr: data.as_ptr() as _,


### PR DESCRIPTION
structs should begin with uppercase

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
